### PR TITLE
fix: Fix vps acquisition channel ID logic and some other issues

### DIFF
--- a/src/vpp_swap/src/x3_sdk_camera.cpp
+++ b/src/vpp_swap/src/x3_sdk_camera.cpp
@@ -220,6 +220,8 @@ int x3_cam_vps_init_param(x3_modules_info_t *info, const int pipe_id, int chn_nu
                 ret |= vps_chn_rotate_param_init(&info->m_vps_infos.m_vps_info[0].m_vps_chn_attrs[chn_index],
                     rotate[i] % ROTATION_MAX);
             }
+            printf("Setting VPS channel-%d: src_w:%d, src_h:%d; dst_w:%d, dst_h:%d;\n", chn_data,
+                src_width, src_height, dst_width[i], dst_height[i]);
             chn_en |= 1 << chn_data;
             chn_index++;
         } else {
@@ -516,7 +518,7 @@ static int GetSifRawData(const int pipe_id, ImageFrame *image_frame, const int t
 #if EN_PRINT_INFO
         printf("pipe:%d dump normal sif frame id(%ld),plane(%d)size(%d)\n",
                pipe_id, image_frame->image_id, sif_img->img_info.planeCount,
-               size);
+               data_size);
 #endif
     } else if (sif_img->img_info.planeCount == 2) { // yuv的 planeCount是2
         data_size = sif_img->img_info.size[0] + sif_img->img_info.size[1];
@@ -539,7 +541,7 @@ static int GetSifRawData(const int pipe_id, ImageFrame *image_frame, const int t
 #if EN_PRINT_INFO
         printf("pipe:%d dump normal sif frame id(%ld),plane(%d)size(%d)\n",
                pipe_id, image_frame->image_id, sif_img->img_info.planeCount,
-               size);
+               data_size);
 #endif
     } else {
         printf("pipe:%d raw buf planeCount wrong !!!\n", pipe_id);
@@ -600,7 +602,7 @@ static int GetISPYuvData(const int pipe_id, ImageFrame *image_frame, const int t
 #if EN_PRINT_INFO
         printf("pipe:%d dump normal raw frame id(%ld),plane(%d)size(%d)\n",
                pipe_id, image_frame->image_id, isp_yuv->img_info.planeCount,
-               size);
+               data_size);
 #endif
     } else {
         printf("pipe:%d isp yuv buf planeCount wrong !!!\n", pipe_id);
@@ -661,7 +663,7 @@ static int GetVpsChnData(const int pipe_id, int chn_id, ImageFrame *image_frame,
 #if EN_PRINT_INFO
         printf("pipe:%d dump normal raw frame id(%ld),plane(%d)size(%d)\n",
                pipe_id, image_frame->image_id, vps_yuv->img_info.planeCount,
-               size);
+               data_size);
 #endif
     } else {
         printf("pipe:%d isp yuv buf planeCount wrong !!!\n", pipe_id);
@@ -810,9 +812,11 @@ int VPPCamera::GetChnId(Sdk_Object_e object, int for_bind, int width, int height
         if (for_bind) {
             // for bind
             if (chn_attr->m_is_bind == VPP_CAMERA) {
-                if (width != 0 && height != 0 &&
-                    width != (int)chn_attr->m_chn_attr.width &&
-                    height != (int)chn_attr->m_chn_attr.height) {
+                if(width == 0 && height == 0){
+                    return chn_attr->m_chn_id;
+                }
+                if ((width != (int)chn_attr->m_chn_attr.width ||
+                    height != (int)chn_attr->m_chn_attr.height)) {
                     continue;
                 }
                 chn_attr->m_is_bind = object;
@@ -821,9 +825,11 @@ int VPPCamera::GetChnId(Sdk_Object_e object, int for_bind, int width, int height
         } else {
             // for unbind
             if (chn_attr->m_is_bind == object) {
-                if (width != 0 && height != 0 &&
-                    width != (int)chn_attr->m_chn_attr.width &&
-                    height != (int)chn_attr->m_chn_attr.height) {
+                if(width == 0 && height == 0){
+                    return chn_attr->m_chn_id;
+                }
+                if ((width != (int)chn_attr->m_chn_attr.width ||
+                    height != (int)chn_attr->m_chn_attr.height)) {
                     continue;
                 }
                 chn_attr->m_is_bind = VPP_CAMERA;

--- a/src/vpp_swap/src/x3_sdk_codec.cpp
+++ b/src/vpp_swap/src/x3_sdk_codec.cpp
@@ -466,7 +466,7 @@ void VPPCodec::x3_do_sync_decoding(void *param)
 
         if (error < 0) {
             if (error == AVERROR_EOF || avContext->pb->eof_reached == HB_TRUE) {
-                LOGE_print("There is no more input data, %d!\n", avpacket.size);
+                LOGD_print("There is no more input data, %d!\n", avpacket.size);
                 eos = false;
                 break;
             } else {

--- a/src/vpp_swap/src/x3_sdk_display.cpp
+++ b/src/vpp_swap/src/x3_sdk_display.cpp
@@ -585,7 +585,7 @@ int VPPDisplay::x3_vot_init(int chn = 0, int width = 1920, int height = 1080,
         upscale_attr.upscale_en = 1;
     }
     ret = HB_VOT_SetVideoLayerUpScale(0, &upscale_attr);
-    if (ret < 0) {
+    if (ret != 0) {
         LOGE_print("Error: failed to HB_VOT_SetVideoLayerUpScale.\n");
     }
 

--- a/src/vpp_swap/src/x3_vio_vdec.c
+++ b/src/vpp_swap/src/x3_vio_vdec.c
@@ -278,7 +278,7 @@ int AV_read_frame(AVFormatContext *avContext, AVPacket *avpacket,
     }
     if (error < 0) {
         if (error == AVERROR_EOF || avContext->pb->eof_reached == 1) {
-            printf("There is no more input data, %d!\n", avpacket->size);
+            LOGD_print("There is no more input data, %d!\n", avpacket->size);
         } else {
             printf("Failed to av_read_frame error(0x%08x)\n", error);
         }


### PR DESCRIPTION
Summary:
	1. Fixed the problem that when two sets of parameters with the same width or height are passed in, vps can only obtain the data of the first channel. [RDK-88](https://jira.hobot.cc:8443/browse/RDK-88)
	2. Reduce the printing level of "There is no more input data". [RDK-85](https://jira.hobot.cc:8443/browse/RDK-85)
	3. Adjust HB_VOT_SetVideoLayerUpScale return value judgment 